### PR TITLE
Fix reward model checkpoint path handling

### DIFF
--- a/training_reward_model.py
+++ b/training_reward_model.py
@@ -307,4 +307,4 @@ trainer = RewardTrainer(
 trainer.train(script_args.resume_from_checkpoint)
 
 print("Saving last checkpoint of the model")
-model.save_pretrained(script_args.output_dir + "peft_last_checkpoint")
+model.save_pretrained(os.path.join(script_args.output_dir, "peft_last_checkpoint"))


### PR DESCRIPTION
## Summary
- avoid string concatenation when saving final reward model checkpoint

## Testing
- `python -m py_compile training_reward_model.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ca60fed7883288b932419e1a8a22d